### PR TITLE
CORCI-589 Code linting overhaul

### DIFF
--- a/check_json.sh
+++ b/check_json.sh
@@ -32,9 +32,13 @@ fi
 rc=0
 pushd "${PROJECT_REPO}" > /dev/null || exit 1
 
-  file_list1=$(git "${git_args[@]}")
+  if [ -n "$FILELIST" ]; then
+    file_list="$FILELIST"
+  else
+    file_list1=$(git "${git_args[@]}")
 
-  file_list=${file_list1//$'\n'/ }
+    file_list=${file_list1//$'\n'/ }
+  fi
 
   for script_file in ${file_list}; do
 

--- a/check_make_output.sh
+++ b/check_make_output.sh
@@ -33,8 +33,12 @@ if [ ! -e "${MAKE_OUTPUT}" ]; then
 fi
 
 # Only output lines for the files in the review.
-pushd "${PROJECT_REPO}" >> /dev/null || exit 1
-  file_list1=$(git "${git_args[@]}")
-popd >> /dev/null || exit 1
-file_list=${file_list1//$'\n'/|}
+if [ -n "$FILELIST" ]; then
+  file_list="$FILELIST"
+else
+  pushd "${PROJECT_REPO}" >> /dev/null || exit 1
+    file_list1=$(git "${git_args[@]}")
+  popd >> /dev/null || exit 1
+  file_list=${file_list1//$'\n'/|}
+fi
 grep -E "${file_list}" "${MAKE_OUTPUT}"

--- a/check_python.sh
+++ b/check_python.sh
@@ -89,9 +89,13 @@ fi
 
 rc=0
 pushd "${PROJECT_REPO}" > /dev/null || exit 1
-  file_list1=$(git "${git_args[@]}")
+  if [ -n "$FILELIST" ]; then
+    file_list="$FILELIST"
+  else
+    file_list1=$(git "${git_args[@]}")
 
-  file_list=${file_list1//$'\n'/ }
+    file_list=${file_list1//$'\n'/ }
+  fi
 
   rm -f "${PYLINT_OUT}"
 

--- a/check_ruby.sh
+++ b/check_ruby.sh
@@ -32,9 +32,13 @@ fi
 rc=0
 pushd "${PROJECT_REPO}" > /dev/null || exit 1
 
-  file_list1=$(git "${git_args[@]}")
+  if [ -n "$FILELIST" ]; then
+    file_list="$FILELIST"
+  else
+    file_list1=$(git "${git_args[@]}")
 
-  file_list=${file_list1//$'\n'/ }
+    file_list=${file_list1//$'\n'/ }
+  fi
 
   for script_file in ${file_list}; do
 

--- a/check_yaml.sh
+++ b/check_yaml.sh
@@ -32,10 +32,13 @@ fi
 rc=0
 pushd "${PROJECT_REPO}" > /dev/null || exit 1
 
-  file_list1=$(git "${git_args[@]}")
+  if [ -n "$FILELIST" ]; then
+    file_list="$FILELIST"
+  else
+    file_list1=$(git "${git_args[@]}")
 
-  file_list=${file_list1//$'\n'/ }
-
+    file_list=${file_list1//$'\n'/ }
+  fi
   for script_file in ${file_list}; do
 
     if [ -f "${script_file}" ] &&

--- a/jenkins_github_checkwarn.sh
+++ b/jenkins_github_checkwarn.sh
@@ -12,12 +12,12 @@ if [ -n "${GERRIT_PROJECT-}" ]; then
 else
   checkpatch_py="github_checkpatch.py"
 fi
-checkpatch_py="$(find "${mydir}" -name $checkpatch_py -print -quit)"
+checkpatch_py="$(find -L "${mydir}" -name $checkpatch_py -print -quit)"
 
-check_make="$(find "${mydir}" -name check_make_output.sh -print -quit)"
-check_style="$(find "${mydir}" -name checkpatch.pl -print -quit)"
-check_shell="$(find "${mydir}" -name shellcheck_scripts.sh -print -quit)"
-check_python="$(find "${mydir}" -name check_python.sh -print -quit)"
+check_make="$(find -L "${mydir}" -name check_make_output.sh -print -quit)"
+check_style="$(find -L "${mydir}" -name checkpatch.pl -print -quit)"
+check_shell="$(find -L "${mydir}" -name shellcheck_scripts.sh -print -quit)"
+check_python="$(find -L "${mydir}" -name check_python.sh -print -quit)"
 
 # For a matrix review we only want to default for the full check for the
 # el7 target, just compiler warnings for the rest.

--- a/shellcheck_scripts.sh
+++ b/shellcheck_scripts.sh
@@ -32,9 +32,13 @@ fi
 rc=0
 pushd "${PROJECT_REPO}" > /dev/null || exit 1
 
-  file_list1=$(git "${git_args[@]}")
+  if [ -n "$FILELIST" ]; then
+    file_list="$FILELIST"
+  else
+    file_list1=$(git "${git_args[@]}")
 
-  file_list=${file_list1//$'\n'/ }
+    file_list=${file_list1//$'\n'/ }
+  fi
 
   for script_file in ${file_list}; do
 


### PR DESCRIPTION
Various fixes to the way the code linting works with GitHub PRs:
- Get the content of the patch from GitHub instead of trying to get
  it from the local checkout
  - I'm not convinced that it cannot be done using the local checkout
    but it will just take some investigating on how to do it
- Once we have that patch, enumerate the files changed and pass those
  to the linters (except checkpatch)
- Then use that list of files to only put a comment into the PR about
  lines that were in the files in the patch
- Fix a bug where relative paths with a leading ./ coming from pylint
  were not being considered by the output parser
- Only increment warning count for files in the patch
