### PR TITLE
CORCI-787 checkpatch: Ignore STATIC_CONST_CHAR_ARRAY

### DIFF
--- a/jenkins_github_checkwarn.sh
+++ b/jenkins_github_checkwarn.sh
@@ -2,7 +2,7 @@
 
 # comma separated list
 def_ignore="SPLIT_STRING,SSCANF_TO_KSTRTO,PREFER_KERNEL_TYPES,BRACES"
-def_ignore+=",USE_NEGATIVE_ERRNO,CAMELCASE"
+def_ignore+=",USE_NEGATIVE_ERRNO,CAMELCASE,STATIC_CONST_CHAR_ARRAY"
 
 : "${IGNORE:="${def_ignore}"}"
 


### PR DESCRIPTION
Silence warnings about const use for static const char*
arrays.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>