### PR TITLE
CORCI-27 test: Use codespell dictionary in checkpatch if it's available.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,6 @@ pipeline {
                     }
                     steps {
                         checkPatch review_creds: 'daos-jenkins-review-posting',
-                                   branch: "ampittma-codespell",
                                    ignored_files: "test/*"
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,7 @@ pipeline {
                     }
                     steps {
                         checkPatch review_creds: 'daos-jenkins-review-posting',
+                                   branch: "ampittma-codespell",
                                    ignored_files: "test/*"
                     }
                     post {

--- a/github_checkpatch.py
+++ b/github_checkpatch.py
@@ -83,10 +83,16 @@ CHECKPATCH_ARGS = []
 try:
     # Dont allow common spelling mistakes.
     import codespell_lib
+    try:
+        d_file = codespell_lib.default_dictionary
+    except AttributeError:
+        d_file = os.path.join(codespell_lib._data_root,
+                                         'dictionary.txt')
+
     CHECKPATCH_ARGS.extend(['--codespell',
                             '--codespellfile',
-                            os.path.join(codespell_lib._data_root,
-                                         'dictionary.txt')])
+                            d_file])
+
 except ImportError:
     pass
 

--- a/github_checkpatch.py
+++ b/github_checkpatch.py
@@ -80,8 +80,10 @@ def _getenv_list(key, default=None, sep=':'):
 BUILD_URL = os.getenv('BUILD_URL', None)
 
 CHECKPATCH_ARGS = []
+
+# Try to use codespell if it's available.  This works for at least
+# 1.16 and 1.17.
 try:
-    # Dont allow common spelling mistakes.
     import codespell_lib._codespell
     try:
         d_file = codespell_lib._codespell.default_dictionary

--- a/github_checkpatch.py
+++ b/github_checkpatch.py
@@ -82,12 +82,12 @@ BUILD_URL = os.getenv('BUILD_URL', None)
 CHECKPATCH_ARGS = []
 try:
     # Dont allow common spelling mistakes.
-    import codespell_lib
+    import codespell_lib._codespell
     try:
-        d_file = codespell_lib.default_dictionary
+        d_file = codespell_lib._codespell.default_dictionary
     except AttributeError:
-        d_file = os.path.join(codespell_lib._data_root,
-                                         'dictionary.txt')
+        d_file = os.path.join(codespell_lib._codespell._data_root,
+                              'dictionary.txt')
 
     CHECKPATCH_ARGS.extend(['--codespell',
                             '--codespellfile',

--- a/github_checkpatch.py
+++ b/github_checkpatch.py
@@ -79,9 +79,19 @@ def _getenv_list(key, default=None, sep=':'):
 
 BUILD_URL = os.getenv('BUILD_URL', None)
 
+CHECKPATCH_ARGS = []
+try:
+    import codespell_lib
+    CHECKPATCH_ARGS.extend(['--codespell',
+                            '--codespellfile',
+                            os.path.join(codespell_lib._data_root,
+                                         'dictionary.txt')])
+except ImportError:
+    pass
 
 CHECKPATCH_PATHS = _getenv_list('CHECKPATCH_PATHS', ['checkpatch.pl'])
-CHECKPATCH_ARGS = os.getenv('CHECKPATCH_ARGS', '--show-types -').split(' ')
+CHECKPATCH_EXTRA_ARGS = os.getenv('CHECKPATCH_ARGS', '--show-types -').split(' ')
+CHECKPATCH_ARGS.extend(CHECKPATCH_EXTRA_ARGS)
 CHECKPATCH_IGNORED_FILES = _getenv_list('CHECKPATCH_IGNORED_FILES', [
     'lustre/contrib/wireshark/packet-lustre.c',
     'lustre/ptlrpc/wiretest.c',

--- a/github_checkpatch.py
+++ b/github_checkpatch.py
@@ -81,6 +81,7 @@ BUILD_URL = os.getenv('BUILD_URL', None)
 
 CHECKPATCH_ARGS = []
 try:
+    # Dont allow common spelling mistakes.
     import codespell_lib
     CHECKPATCH_ARGS.extend(['--codespell',
                             '--codespellfile',

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -9,5 +9,5 @@ MAINTAINER Brian J. Murrell <brian.murrell@intel.com>
 
 RUN yum install -y epel-release
 RUN yum install -y python-requests python-github perl ShellCheck git
-RUN yum install -y python3-pip
-RUN pip3 install codespell
+RUN yum install -y python-pip
+RUN pip install codespell

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -9,3 +9,5 @@ MAINTAINER Brian J. Murrell <brian.murrell@intel.com>
 
 RUN yum install -y epel-release
 RUN yum install -y python-requests python-github perl ShellCheck git
+RUN yum install -y python3-pip
+RUN pip3 install codespell


### PR DESCRIPTION
When setting up the args for checkpatch try and import codespell, and use the dictionary file from there to check for common spelling mistakes.  This needs the codespell package installed to work, so add it here for the code_review repo, but daos will also need it added.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>