### PR TITLE
CORCI-27 test: Add code to give suggestions to github.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,7 @@ pipeline {
                         ./jenkins_github_checkwarn.sh |
                           sed -e '/^commit:/s/".*"/"..."/' \
                               -e 's/blob\\/.*\\/test/blob\\/...\\/test/' \
-                              -e '/^Style warning(s) for job/s/https.*/.../' > "\$tmpfile"
+                              -e '/ Style warning(s) for job/s/https.*/.../' > "\$tmpfile"
 
                         diff -u "\$tmpfile" test/expected_output"""
                 }

--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -258,7 +258,7 @@ our $Ident	= qr{
 			[A-Za-z_][A-Za-z\d_]*
 			(?:\s*\#\#\s*[A-Za-z_][A-Za-z\d_]*)*
 		}x;
-our $Storage	= qr{extern|static|asmlinkage};
+our $Storage	= qr{extern|static|asmlinkage|ATOMIC};
 our $Sparse	= qr{
 			__user|
 			__kernel|
@@ -612,6 +612,9 @@ our $declaration_macros = qr{(?x:
 	(?:$Storage\s+)?(?:[A-Z_][A-Z0-9]*_){0,2}(?:DEFINE|DECLARE)(?:_[A-Z0-9]+){1,6}\s*\(|
 	(?:$Storage\s+)?LIST_HEAD\s*\(|
 	(?:$Storage\s+)?TAILQ_ENTRY\s*\(|
+	(?:$Storage\s+)?TAILQ_HEAD\s*\(|
+	(?:$Storage\s+)?D_CIRCLEQ_HEAD\s*\(|
+	(?:$Storage\s+)?CIRCLEQ_HEAD\s*\(|
 	(?:$Storage\s+)?STAILQ_ENTRY\s*\(|
 	(?:$Storage\s+)?LIST_ENTRY\s*\(|
 	(?:$Storage\s+)?${Type}\s+uninitialized_var\s*\(

--- a/jenkins_github_checkwarn.sh
+++ b/jenkins_github_checkwarn.sh
@@ -88,7 +88,14 @@ if [ -n "${GERRIT_PROJECT-}" ]; then
   set -u
 fi
 
-python "${checkpatch_py}"
+if [ -x ./ci/patch_src_in_place ]
+then
+    ./ci/patch_src_in_place
+fi
+
+python3 "${checkpatch_py}"
 result=$?
+
+git checkout .
 
 exit ${result}

--- a/test/expected_output
+++ b/test/expected_output
@@ -11,7 +11,7 @@ FYI: Errors found in lines not modified in the patch:
 event: REQUEST_CHANGES
 comments (1):
 
-[   {   'body': '(lint) Double quote to prevent globbing and word splitting.'
+[   {   'body': '(lint) Double quote to prevent globbing and word splitting. '
                 '[SC2086]',
-        'position': 3,
+        'line': 3,
         'path': 'test/shell_error.sh'}]

--- a/test/expected_output
+++ b/test/expected_output
@@ -11,6 +11,7 @@ FYI: Errors found in lines not modified in the patch:
 event: REQUEST_CHANGES
 comments (1):
 
-[   {   'body': '(lint) Double quote to prevent globbing and word splitting. [SC2086]',
-        'path': 'test/shell_error.sh',
-        'position': 3}]
+[   {   'body': '(lint) Double quote to prevent globbing and word splitting.'
+                '[SC2086]',
+        'position': 3,
+        'path': 'test/shell_error.sh'}]

--- a/test/expected_output
+++ b/test/expected_output
@@ -1,6 +1,6 @@
 commit:  Commit(sha="...")
 review_comment:
-Style warning(s) for job ...
+ Style warning(s) for job ...
 Please review https://wiki.hpdd.intel.com/display/DC/Coding+Rules
 
 FYI: Errors found in lines not modified in the patch:

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -8,6 +8,10 @@ FROM centos:7
 MAINTAINER Brian J. Murrell <brian.murrell@intel.com>
 
 RUN yum install -y epel-release
-RUN yum install -y python-requests python-github perl ShellCheck git
-RUN yum install -y python-pip
-RUN pip install codespell
+RUN yum install -y python-requests perl ShellCheck git
+RUN yum install -y python3-pip
+# Only needed until this PR lands, then it can be removed.
+RUN yum install -y python-github
+
+RUN pip3 install codespell
+RUN pip3 install pygithub


### PR DESCRIPTION
Add support for giving suggestions back to patches in github.
If a script with the right name exits in the source then call it
to patch the src tree in place, then run "git diff" to parse these
changes and report them back to github as suggestions.

Port github_checkpatch to python3, which requires docker/package
changes.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>