### PR TITLE
CORCI-974 checkpatch: Resolve issues with RPC definitions.

### DIFF
--- a/checkpatch.pl
+++ b/checkpatch.pl
@@ -2799,7 +2799,7 @@ sub process {
 #   known attributes or the __attribute__ keyword
 		if ($line =~ /^\+(.*)\(\s*$Type\s*\)([ \t]++)((?![={]|\\$|$Attribute|__attribute__))/ &&
 		    (!defined($1) || $1 !~ /\b(?:sizeof|__alignof__)\s*$/)) {
-			if (CHK("SPACING",
+			if (CHK("SPACING_CAST",
 				"No space is necessary after a cast\n" . $herecurr) &&
 			    $fix) {
 				$fixed[$fixlinenr] =~


### PR DESCRIPTION
Make the "no space after cast" check have a unique name so
that it can be disabled on a per-file basis.
Do not hard-code the github username.
Add better handing of specific error when this error happens.
Fix bug where patch change was processed with wrong filename.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>