### PR TITLE
CORCI-1014 build: Run all lint scripts

### DIFF
--- a/checkpatch_lint.sh
+++ b/checkpatch_lint.sh
@@ -5,8 +5,20 @@ mydir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 : "${PROJECT_REPO:=$mydir}"
 : "${CODE_REVIEW:=$mydir}"
 export PROJECT_REPO
-"$CODE_REVIEW/check_json.sh"
-"$CODE_REVIEW/check_python.sh"
-"$CODE_REVIEW/check_ruby.sh"
-"$CODE_REVIEW/check_yaml.sh"
-"$CODE_REVIEW/shellcheck_scripts.sh"
+result=0
+if ! "$CODE_REVIEW/check_json.sh"; then
+  result=1
+fi
+if ! "$CODE_REVIEW/check_python.sh"; then
+  result=1
+fi
+if ! "$CODE_REVIEW/check_ruby.sh"; then
+  result=1
+fi
+if ! "$CODE_REVIEW/check_yaml.sh"; then
+  result=1
+fi
+if ! "$CODE_REVIEW/shellcheck_scripts.sh"; then
+  result=1
+fi
+exit $result


### PR DESCRIPTION
The checkpatch_lint.sh script needs to run all the linting scripts
and not stop on the first report.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>