### PR TITLE
DAOS-623 lint: Ignore typedefs

### DIFF
--- a/jenkins_github_checkwarn.sh
+++ b/jenkins_github_checkwarn.sh
@@ -3,6 +3,7 @@
 # comma separated list
 def_ignore="SPLIT_STRING,SSCANF_TO_KSTRTO,PREFER_KERNEL_TYPES,BRACES"
 def_ignore+=",USE_NEGATIVE_ERRNO,CAMELCASE,STATIC_CONST_CHAR_ARRAY"
+def_ignore+=",NEW_TYPEDEFS"
 
 : "${IGNORE:="${def_ignore}"}"
 


### PR DESCRIPTION
We use typedefs in DAOS.  It's annoying to warn about it when following
prior convention.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>